### PR TITLE
add terminus 3 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,19 @@ This will update the autocomplete commands and should be executed after every ne
 Learn more about [Terminus](https://pantheon.io/docs/terminus/) and [Terminus Plugins](https://pantheon.io/docs/terminus/plugins/).
 
 ## Installation:
-For installation help, see [Manage Plugins](https://pantheon.io/docs/terminus/plugins/).
 
+To install this plugin using Terminus 3:
+```
+terminus self:plugin:install terminus-plugin-project/terminus-autocomplete-plugin
+```
+
+On older versions of Terminus:
 ```
 mkdir -p ~/.terminus/plugins
-composer create-project -d ~/.terminus/plugins terminus-plugin-project/terminus-autocomplete-plugin:~2
+composer create-project --no-dev -d ~/.terminus/plugins terminus-plugin-project/terminus-autocomplete-plugin
 ```
+For help installing, see [Manage Plugins](https://pantheon.io/docs/terminus/plugins/).
+
 
 ## Requirements:
 


### PR DESCRIPTION
* copied from https://github.com/pantheon-systems/terminus-rsync-plugin/blob/f7d4a668aa01fd14cab42de17b6ddfbc0abb0741/README.md
* On my machine, I needed the vendor prefix for non-`pantheon-systems` plugins, so that's what I wrote in these instructions.